### PR TITLE
Fixed most of the clippy issues

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,7 @@ use tui::{
     widgets::{Block, BorderType, Borders, Cell, List, ListItem, Paragraph, Row, Table},
 };
 
-const SPLASH: &'static str = r#"
+const SPLASH: &str = r#"
  . .................................................................................................
   . ................................................................................................
 . . ........nnnnMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMnnnn......... .
@@ -72,7 +72,7 @@ impl App {
     pub fn new(config: &Config) -> App {
         let user = config.default_user.clone();
         App {
-            mode: if user.len() == 0 {
+            mode: if user.is_empty() {
                 Mode::Login
             } else {
                 Mode::Loading

--- a/src/app.rs
+++ b/src/app.rs
@@ -243,7 +243,7 @@ impl App {
                     spacer.clone(),
                 ];
                 // Construct table details
-                for (heading, value) in vec![
+                for &(heading, value) in &[
                     ("Homepage", &selected.homepage),
                     ("Developer", &selected.developer),
                     ("Publisher", &selected.publisher),
@@ -258,7 +258,7 @@ impl App {
                 }
                 if let Some(status) = status {
                     table.push(spacer.clone());
-                    for (heading, value) in vec![
+                    for &(heading, value) in &[
                         ("State", &status.state),
                         ("Installation", &status.installdir),
                         ("Size", &convert(status.size)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,6 @@ use crate::util::error::STError;
 use crate::util::paths::config_location;
 
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::fs;
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use std::io;
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{backend::TermionBackend, layout::Rect, Terminal};
 
-use image;
 use tui_image_rgba_updated::{ColorMode, Image};
 
 use steam_tui::util::event::{Event, Events};
@@ -109,12 +108,11 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
 
         if let Event::Input(input) = events.next()? {
             match app.mode {
-                Mode::Terminated(_) => match input {
-                    Key::Char('q') => {
+                Mode::Terminated(_) => {
+                    if let Key::Char('q') = input {
                         break;
                     }
-                    _ => {}
-                },
+                }
                 Mode::Normal | Mode::Searched => match input {
                     Key::Char('l') => {
                         app.mode = Mode::Login;
@@ -158,7 +156,7 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
                 Mode::Login | Mode::Failed => match input {
                     Key::Esc => {
                         if client.is_logged_in()? {
-                            if game_list.query.len() > 0 {
+                            if game_list.query.is_empty() {
                                 app.mode = Mode::Normal;
                             } else {
                                 app.mode = Mode::Searched;
@@ -208,7 +206,7 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
                 _ => {}
             }
         }
-        if &app.mode == &Mode::Loading {
+        if app.mode == Mode::Loading {
             match client.get_state()? {
                 State::Loaded(_, -2) => {
                     client.load_games()?;

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -1,6 +1,5 @@
 use crate::util::parser::Command;
 
-use serde_json;
 use shellexpand::LookupError;
 use std::error;
 use std::fmt;

--- a/src/util/event.rs
+++ b/src/util/event.rs
@@ -50,15 +50,13 @@ impl Events {
             let stop = stop.clone();
             thread::spawn(move || {
                 let stdin = io::stdin();
-                for evt in stdin.keys() {
-                    if let Ok(key) = evt {
-                        if let Err(err) = tx.send(Event::Input(key)) {
-                            eprintln!("{}", err);
-                            return;
-                        }
-                        if stop.load(Ordering::Relaxed) {
-                            return;
-                        }
+                for key in stdin.keys().flatten() {
+                    if let Err(err) = tx.send(Event::Input(key)) {
+                        eprintln!("{}", err);
+                        return;
+                    }
+                    if stop.load(Ordering::Relaxed) {
+                        return;
                     }
                 }
             })
@@ -80,6 +78,12 @@ impl Events {
 
     pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
         self.rx.recv()
+    }
+}
+
+impl Default for Events {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/util/parser.rs
+++ b/src/util/parser.rs
@@ -24,11 +24,11 @@ impl Lexer {
             captures
                 .iter() // All the captured groups
                 .skip(1) // Skipping the complete match
-                .flat_map(|c| c) // Ignoring all empty optional matches
+                .flatten() // Ignoring all empty optional matches
                 .map(|c| c.as_str()) // Grab the original strings
                 .collect::<Vec<_>>() // Create a vector
         });
-        captures.unwrap_or_else(|| Vec::new())
+        captures.unwrap_or_else(Vec::new)
     }
 }
 
@@ -99,14 +99,14 @@ pub enum Command {
 pub fn parse(block: &mut dyn Iterator<Item = &str>) -> Datum {
     let mut map = HashMap::new();
     while let Some(line) = block.next() {
-        match DATA_LEX.tokenize(&line).as_slice() {
-            &["}"] => {
+        match *DATA_LEX.tokenize(&line).as_slice() {
+            ["}"] => {
                 break;
             }
-            &[key, value] => {
+            [key, value] => {
                 map.insert(key.to_string(), Datum::Value(value.to_string()));
             }
-            &[key] => {
+            [key] => {
                 block.next();
                 map.insert(key.to_string(), parse(block));
             }

--- a/src/util/paths.rs
+++ b/src/util/paths.rs
@@ -1,6 +1,5 @@
 use crate::util::error::STError;
 
-use shellexpand;
 use std::io::Write;
 use std::{
     env, fs, io,
@@ -38,11 +37,11 @@ pub fn steam_directory() -> Result<PathBuf, STError> {
     Ok(dir.to_path_buf())
 }
 
-pub fn executable_join(executable: &String, installdir: &String) -> Result<PathBuf, STError> {
+pub fn executable_join(executable: &str, installdir: &str) -> Result<PathBuf, STError> {
     let installdir = Path::new(installdir);
     let executable = Path::new(executable);
     let script_path = installdir.join(executable);
-    Ok(script_path.to_path_buf())
+    Ok(script_path)
 }
 
 pub fn image_exists(id: i32) -> Result<PathBuf, STError> {
@@ -51,7 +50,7 @@ pub fn image_exists(id: i32) -> Result<PathBuf, STError> {
     let image = Path::new(image);
     let image = dir.join(image);
     if image.exists() {
-        Ok(image.to_path_buf())
+        Ok(image)
     } else {
         Err(STError::Problem(format!(
             "Image doesn't exist: {:?}",
@@ -60,12 +59,12 @@ pub fn image_exists(id: i32) -> Result<PathBuf, STError> {
     }
 }
 
-pub fn executable_exists(executable: &String) -> Result<PathBuf, STError> {
+pub fn executable_exists(executable: &str) -> Result<PathBuf, STError> {
     let dir = steam_directory()?;
     let executable = Path::new(executable);
     let script_path = dir.join(executable);
     if script_path.exists() {
-        Ok(script_path.to_path_buf())
+        Ok(script_path)
     } else {
         Err(STError::Problem("Executable doesn't exist".to_string()))
     }
@@ -75,7 +74,7 @@ pub fn install_script_location(login: String, id: i32) -> Result<PathBuf, STErro
     let dir = config_directory()?;
     let script_path = &format!("{}.install", id);
     let script_path = Path::new(script_path);
-    let script_path = dir.join(script_path.clone());
+    let script_path = dir.join(script_path);
     let mut f = fs::File::create(&script_path)?;
     let contents = format!(
         r#"
@@ -86,7 +85,7 @@ quit
         login, id
     );
     f.write_all(contents.as_bytes())?;
-    Ok(script_path.to_path_buf())
+    Ok(script_path)
 }
 
 pub fn config_location() -> Result<PathBuf, STError> {
@@ -94,7 +93,7 @@ pub fn config_location() -> Result<PathBuf, STError> {
     let config_path = Path::new("config.json");
     let config_path = dir.join(config_path);
     touch(&config_path)?;
-    Ok(config_path.to_path_buf())
+    Ok(config_path)
 }
 
 pub fn cache_location() -> Result<PathBuf, STError> {
@@ -102,5 +101,5 @@ pub fn cache_location() -> Result<PathBuf, STError> {
     let config_path = Path::new("games.json");
     let config_path = dir.join(config_path);
     touch(&config_path)?;
-    Ok(config_path.to_path_buf())
+    Ok(config_path)
 }

--- a/src/util/stateful.rs
+++ b/src/util/stateful.rs
@@ -32,14 +32,12 @@ impl<T: Named> StatefulList<T> {
     }
 
     pub fn selected(&self) -> Option<&T> {
-        match self.state.selected() {
-            Some(i) => Some(
-                self.activated()
-                    .get(i)
-                    .expect("Index is guarded by next, previous. This is safe."),
-            ),
-            None => None,
-        }
+        self.state.selected().map(|i| {
+            *self
+                .activated()
+                .get(i)
+                .expect("Index is guarded by next, previous. This is safe.")
+        })
     }
 
     pub fn activated(&self) -> Vec<&T> {
@@ -52,12 +50,11 @@ impl<T: Named> StatefulList<T> {
                     .is_some()
             })
             .filter(|nameable| nameable.is_valid())
-            .map(|nameable| nameable.clone())
             .collect::<Vec<_>>()
     }
 
     pub fn restart(&mut self) {
-        if self.activated().len() == 0 {
+        if self.activated().is_empty() {
             self.state.select(None);
         } else {
             self.state.select(Some(0));
@@ -93,5 +90,11 @@ impl<T: Named> StatefulList<T> {
     }
     pub fn unselect(&mut self) {
         self.state.select(None);
+    }
+}
+
+impl<T: Named> Default for StatefulList<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
See #15

Still outstanding clippy issue, that is causing problems:
```
warning: useless use of `vec!`
   --> src/app.rs:261:45
    |
261 |                       for (heading, value) in vec![
    |  _____________________________________________^
262 | |                         ("State", &status.state),
263 | |                         ("Installation", &status.installdir),
264 | |                         ("Size", &convert(status.size)),
265 | |                     ] {
    | |_____________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
help: you can use a slice directly
    |
261 |                     for (heading, value) in &[("State", &status.state),
262 |                         ("Installation", &status.installdir),
263 |                         ("Size", &convert(status.size))] {
```

Which is not as straight forward as you'd think, because lifetime should be implicit, and the suggest fix breaks that.

Also need to throw in a github action for clippy