### PR TITLE
Proper theming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "coolor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +785,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "terminal-light",
  "termion",
  "tui",
  "tui-image-rgba-updated",
@@ -1349,6 +1369,18 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07063eee8d7fdc8dd56ed0e6668b0ead96815410a5e3ebeedf4eceb6f49f914"
+dependencies = [
+ "coolor",
+ "crossterm",
+ "thiserror",
+ "xterm-query",
 ]
 
 [[package]]
@@ -1753,4 +1785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xterm-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec02abe9c7efbcb010adc0d90bc4a054653477cd4a3eb8eef5a689799c146a13"
+dependencies = [
+ "mio",
+ "nix",
+ "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = "1.0", features = ["derive"] }
 
 termion = { version = "1.5"}
 tui = { version = "0.18", default-features = false, features = ['termion', 'serde'] }
+terminal-light = "1.0.0"
 
 fuzzy-matcher = "0.3.7"
 lazy_static = "1.4.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,7 +144,6 @@ impl App {
             .block(
                 Block::default()
                     .borders(Borders::all())
-                    .style(Style::default().fg(Color::White))
                     .title(title)
                     .border_type(BorderType::Plain),
             )
@@ -210,7 +209,6 @@ impl App {
     ) -> (List<'a>, Table<'a>) {
         let games = Block::default()
             .borders(Borders::ALL)
-            .style(Style::default().fg(Color::White))
             .title("Games")
             .border_type(BorderType::Plain);
 
@@ -218,30 +216,27 @@ impl App {
             .activated()
             .iter()
             .map(|game| {
-                let fg = {
+                let modifier = {
                     if let Some(status) = game.get_status() {
                         if status.state == "uninstalled" || status.state.contains("Failed") {
-                            Color::DarkGray
+                            Modifier::DIM
                         } else {
-                            Color::White
+                            Modifier::BOLD
                         }
                     } else {
-                        Color::DarkGray
+                        Modifier::DIM
                     }
                 };
                 ListItem::new(Spans::from(vec![Span::styled(
                     game.get_name(),
-                    Style::default().fg(fg),
+                    Style::default().add_modifier(modifier),
                 )]))
             })
             .collect();
 
-        let list = List::new(items).block(games).highlight_style(
-            Style::default()
-                .bg(highlight)
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        );
+        let list = List::new(items)
+            .block(games)
+            .highlight_style(Style::default().bg(highlight).add_modifier(Modifier::BOLD));
 
         let details = match game_list.selected() {
             Some(selected) => {
@@ -301,7 +296,6 @@ impl App {
                     .block(
                         Block::default()
                             .borders(Borders::ALL)
-                            .style(Style::default().fg(Color::White))
                             .title("Detail")
                             .border_type(BorderType::Plain),
                     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,10 @@ extern crate steam_tui;
 use std::io;
 
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
+use tui::style::{Color, Style};
 use tui::{backend::TermionBackend, layout::Rect, Terminal};
+
+use terminal_light;
 
 use tui_image_rgba_updated::{ColorMode, Image};
 
@@ -30,6 +33,11 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
     let stdout = AlternateScreen::from(stdout);
     let backend = TermionBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
+    let terminal_bg = terminal_light::background_color()
+        .map(|c| c.rgb())
+        .map(|c| Color::Rgb(c.r, c.g, c.b))
+        .unwrap_or(Color::Gray);
+
     terminal.clear()?;
     terminal.draw(|frame| {
         let layout = App::build_layout();
@@ -119,7 +127,9 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
                     frame.render_widget(right, game_placement[1]);
                     if let Some(image) = img.clone() {
                         frame.render_widget(
-                            Image::with_img(image).color_mode(ColorMode::Rgba),
+                            Image::with_img(image)
+                                .color_mode(ColorMode::Rgba)
+                                .style(Style::default().bg(terminal_bg)),
                             image_placement[0],
                         )
                     }


### PR DESCRIPTION
To resolve #46 

I removed any explicit references to Color styles in code (except for highliting) and basically let the terminal decide it while rendering the app.
I also used the `terminal_light` crate to determine the terminal's background color and set it as a background for the games' icons.

How it looks like now: 
![1661808846](https://user-images.githubusercontent.com/27929520/187303469-b5cedc16-d151-4cb3-8f0c-79289d5561ea.png)
![1661808735](https://user-images.githubusercontent.com/27929520/187303480-9a2ad6e4-8c32-452e-bb86-d9bdf045aada.png)
