### PR TITLE
nix: remove flake-utils dep & reorganize

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1658632815,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }


### PR DESCRIPTION
All downstream users were needing to pull in flake-utils to just call a for loop which isn’t a good UX. Inlined that loop.

Also moved `steam-tui` into the `packages.steam-tui`. Also allowlisted the nonfree-software rather than allowing it all thru.

`nix build` worked as well as `nix develop`.