### PR TITLE
Fix issue where keys are getting cleared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "steam-tui"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "atty",
  "crossterm 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steam-tui"
-version = "0.2.1"
+version = "0.2.2"
 description = "TUI client for steamcmd."
 readme = "README.md"
 authors = ["madisetti <madisetti@jhu.edu>"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -302,6 +302,10 @@ fn execute(
                         }
                         ["licenses_print"] => {
                             // Extract licenses
+                            if response == "[0m" {
+                                continue;
+                            }
+                            
                             games = Vec::new();
                             let licenses = response.to_string();
                             let keys = keys_from_licenses(licenses);


### PR DESCRIPTION
Keys are getting cleared when steamcmd sends `[0m` back to client.

This occurs after the keys have already been loaded so we can safely ignore it

Not saying this is the best fix as my experience with steamcmd and Rust is quite limited but it worked on my machine & Steam account