### PR TITLE
Fix stderr summary on game crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
+# Unix
+.*
+
+
+# Git
+!.gitignore
+
+
+# Rust
 /target
 *.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "terminal-light",
+ "truncrate",
  "tui",
  "tui-image-rgba-updated",
 ]
@@ -1513,6 +1514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "truncrate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73eead03a57feec88e556e6be8c3f6c9917688a15f9d410aedee1b6cb276445f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 atty = "0.2"
 
 image = "0.24"
+truncrate = "0.1.3"
 
 [dependencies.tui-image-rgba-updated]
 version = "0.2.2"

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,10 @@
               # binary
               self.packages.${system}.steam-tui
             ];
+            packages = with pkgs; [
+              bacon
+              rust-analyzer
+            ];
             STEAM_RUN_WRAPPER = "${pkgs.steam-run}/bin/steam-run";
           };
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -441,8 +441,10 @@ fn execute(
 fn run_process(entry: String, command: Vec<String>, status: Arc<Mutex<Option<GameStatus>>>) {
     match process::Command::new(entry).args(command).output() {
         Ok(output) => {
-            let stderr = output.stderr.clone();
-            let stderr_snippet = &(String::from_utf8_lossy(&stderr)[..50]);
+            let stderr = String::from_utf8(output.stderr.clone()).unwrap();
+            use truncrate::TruncateToBoundary;
+            let stderr_snippet = &stderr.truncate_to_boundary(50);
+
             let mut reference = status.lock().unwrap();
             *reference = Some(GameStatus::msg(
                 &*reference,


### PR DESCRIPTION
I'm seeing some crashes on a game, but after the game crashes steam-tui mishandles the stderr output and tries to show a rust trace instead of the game's crash.

I verified this with `cargo run`, but sadly my missing error was just `failed with code 1: (...)` :cry: 