### PR TITLE
Fix flake for newer versions of nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
         config = {
           allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
             "steam"
+            "steam-unwrapped"
             "steamcmd"
             "steam-original"
             "steam-run"


### PR DESCRIPTION
I decided to add `steam-unwrapped` to the `allowUnfreePredicate` so the flake will still work if someone doesn't follow a newer version of nixpkgs
On older versions of nixpkgs the flake works but on newer version the steam packages works differently and it fails saying that `steam-unwrapped` needs to go in the `allowUnfreePredicate`
Fixes #80 